### PR TITLE
'Enter' keypress logic integrated for selecting currencies easily for a better UX

### DIFF
--- a/src/app/components/converter/converter.component.html
+++ b/src/app/components/converter/converter.component.html
@@ -8,6 +8,7 @@
     class="conversion-area row"
     [formGroup]="converterForm"
     (ngSubmit)="exchangeRates()"
+    (keyup.enter)="$event.preventDefault()"
     novalidate>
 
     <mat-form-field class="margin-sm-right col-12 col-md-12 col-lg-3 col-xl-3">
@@ -26,12 +27,17 @@
             class="pb-0 from-control"
             matInput
             formControlName="fromControl"
-            [matAutocomplete]="fromAutoComplete"
-            (keydown)="selectCurrencyByEnter($event, 'fromControl')">
+            (keydown.enter)="selectWrittenCurrency($event, 'fromControl')"
+            [matAutocomplete]="fromAutoComplete">
 
         <mat-autocomplete #fromAutoComplete="matAutocomplete">
-            <mat-option *ngFor="let fromItem of filteredFromValues | async" [value]="fromItem" class="d-flex justify-content-start">
+            <mat-option
+                *ngFor="let fromItem of filteredFromValues | async"
+                [value]="fromItem"
+                class="d-flex justify-content-start"
+                (onSelectionChange)="selectCurrencyByEnter($event, this.fromCurrency)">
                 <span>{{fromItem}}</span>
+
                 <b class="primary--color">{{ getSymbol(fromItem) }} </b>
             </mat-option>
         </mat-autocomplete>
@@ -51,12 +57,16 @@
             class="pb-0 to-control"
             matInput
             formControlName="toControl"
-            [matAutocomplete]="toAutoComplete"
-            (keydown)="selectCurrencyByEnter($event, 'toControl')">
+            (keydown.enter)="selectWrittenCurrency($event, 'toControl')"
+            [matAutocomplete]="toAutoComplete">
 
         <mat-autocomplete #toAutoComplete="matAutocomplete">
-            <mat-option *ngFor="let toItem of filteredToValues | async" [value]="toItem">
+            <mat-option
+                *ngFor="let toItem of filteredToValues | async"
+                [value]="toItem"
+                (onSelectionChange)="selectCurrencyByEnter($event, this.toCurrency)">
                 <span>{{toItem}}</span>
+
                 <b class="primary--color">{{ getSymbol(toItem) }} </b>
             </mat-option>
         </mat-autocomplete>
@@ -92,7 +102,9 @@
     </section>
 </article>
 
-<article class="row" *ngIf="currencyExchangeService.periodicHistoryExchangeRates.length > 0">
+<article
+    class="row"
+    *ngIf="currencyExchangeService.periodicHistoryExchangeRates.length > 0">
     <div class="col-12 mt-4 mb-2">
         <hr>
     </div>
@@ -113,7 +125,9 @@
         </mat-form-field>
     </div>
 
-    <section class="history-table col-12 mb-4 pl-3 pr-3" *ngIf="this.dataSource.data.length > 0; else noDataTimeline">
+    <section
+        class="history-table col-12 mb-4 pl-3 pr-3"
+        *ngIf="this.dataSource.data.length > 0; else noDataTimeline">
         <div class="row flex-xl-row flex-lg-row flex-md-row flex-sm-column no--padding m-0 mb-4">
             <div class="col-12 col-md-6 col-lg-6 col-xl-6 p-0 pr-lg-2 pr-md-2 pr-xl-2">
                 <table

--- a/src/app/components/converter/converter.component.ts
+++ b/src/app/components/converter/converter.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatAutocompleteTrigger, MatOptionSelectionChange, MatTableDataSource } from '@angular/material';
+import { MatOptionSelectionChange, MatTableDataSource } from '@angular/material';
 import { Observable } from 'rxjs';
-import { map, startWith, take } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 
 import { ExchangeRatesApiRequestService } from '../../shared/service/exchange-rates-api-request.service';
 import { AlertService } from '../../core/alert/alert.service';
@@ -32,9 +32,6 @@ export interface Statistics {
     encapsulation: ViewEncapsulation.None,
 })
 export class ConverterComponent implements OnInit {
-    @ViewChild(MatAutocompleteTrigger)
-    autocomplete: MatAutocompleteTrigger;
-
     public periodicHistoryData: PeriodicHistoryElement[] = this.currencyExchangeService.periodicHistoryExchangeRates;
 
     public dataSource = new MatTableDataSource(this.periodicHistoryData);

--- a/src/app/components/converter/converter.component.ts
+++ b/src/app/components/converter/converter.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatTableDataSource } from '@angular/material';
+import { MatOptionSelectionChange, MatTableDataSource } from '@angular/material';
 import { Observable } from 'rxjs';
-import { map, startWith } from 'rxjs/operators';
+import { map, startWith, take } from 'rxjs/operators';
 
 import { ExchangeRatesApiRequestService } from '../../shared/service/exchange-rates-api-request.service';
 import { AlertService } from '../../core/alert/alert.service';
@@ -80,13 +80,20 @@ export class ConverterComponent implements OnInit {
         this.selectedTimeInterval();
     }
 
-    selectCurrencyByEnter(event, inputName: string): void {
-        if (event.key === 'Enter') {
-            let inputValue: string = this.converterForm.get(inputName).value;
-            inputValue = inputValue.toUpperCase();
-
-            this.converterForm.get(inputName).setValue(inputValue);
+    selectCurrencyByEnter(event: MatOptionSelectionChange, inputName: string): void {
+        if (event.isUserInput) {
+            inputName = event.source.value;
         }
+    }
+
+    selectWrittenCurrency(event: any, inputName: string): void {
+        const writtenCurrency = event.target.value.toUpperCase();
+
+        const currencyList = this.mapItemCurrencies();
+
+        const matchedCurrency = currencyList.filter((currency) => currency === writtenCurrency).toString();
+
+        this.converterForm.controls[inputName].setValue(matchedCurrency);
     }
 
     exchangeRates(): void {

--- a/src/app/shared/service/currency-exchange.service.ts
+++ b/src/app/shared/service/currency-exchange.service.ts
@@ -20,8 +20,8 @@ export interface PeriodicHistoryElement {
 export class CurrencyExchangeService implements OnInit {
     public converterForm: FormGroup = new FormGroup({
         amountControl: new FormControl('', [Validators.required]),
-        fromControl: new FormControl('', [Validators.required]),
-        toControl: new FormControl('', [Validators.required]),
+        fromControl: new FormControl('', [Validators.required, Validators.minLength(2)]),
+        toControl: new FormControl('', [Validators.required, Validators.minLength(2)]),
     });
 
     public exchangeRates: MappedCurrencyRateObject[];


### PR DESCRIPTION
For a better UX on the app usage; 

- 'Enter' keypress now select the first currency on the list,

- By pressing enter key, matching currency will work if the user writes a minimum 2 chars and maximum 3 chars,

